### PR TITLE
README: GitHub web hook change to default to JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ This is a simple PHP script for Github's post-receive webhook
 
 
 6. Create the log directory and file, and make sure the user running apache (www-data) has write access to it.
-7. In your Github repository, add a WebHook URL. Go to Settings/Admin -> Service Hooks -> WebHook URL (https://github.com/your-account/your-repo/settings/hooks). Add in the URL for your deploy.php file, append ?auth=something if you set the AUTH_KEY. For example, http://deploy.example.com/deploy.php?auth=foobar123
+7. In your Github repository, add a WebHook URL. Go to Settings/Admin -> Service Hooks -> WebHook URL (https://github.com/your-account/your-repo/settings/hooks). Add in the URL for your deploy.php file, append ?auth=something if you set the AUTH_KEY. For example, http://deploy.example.com/deploy.php?auth=foobar123 - you'll also need to need to set the content-type to application/x-www-urlencoded
 8. Clone your repository, if you haven't already. Do so as the web server's user, <code>sudo -Hu www-data git clone git@github.com:your-account/your-repo.git</code>
 9. If you go back to the WebHook URL page in Github, you can test your webhook. Check your log, and make sure it's all set!
 


### PR DESCRIPTION
Just a note to let folks know to set the content-tupe to `application/x-ww-urlencoded` when setting up the web hook.
